### PR TITLE
Fix missing Tailwind config

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+const config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add `tailwind.config.mjs` so TailwindCSS can scan the project and build styles

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530e34f8b883298616489814d3b2c0