### PR TITLE
Improve form UX and styling

### DIFF
--- a/app/form/step1/page.js
+++ b/app/form/step1/page.js
@@ -36,14 +36,28 @@ export default function Step1() {
   
   return (
     <QuestionWrapper steps={steps} onFinish={handleFinish}>
-      {({ step, onNext }) => {
+      {({ step, onNext, onSubmit }) => {
         if (step.key === "age") {
           return (
             <div className="space-y-3">
               <input
                 type="number"
-                className="border px-4 py-2 w-full rounded"
-                onChange={(e) => onNext(e.target.value)}
+                min="1"
+                inputMode="numeric"
+                className="border px-4 py-2 w-full rounded focus:ring-2 focus:ring-indigo-600"
+                onChange={(e) => {
+                  const val = parseInt(e.target.value, 10);
+                  if (val >= 1) {
+                    onNext(val);
+                  } else {
+                    onNext(undefined);
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    onSubmit();
+                  }
+                }}
               />
             </div>
           );
@@ -61,11 +75,11 @@ export default function Step1() {
                     setSelectedGender(gender);
                     onNext(gender);
                   }}
-                  className={`w-full px-4 py-2 rounded border text-center
+                  className={`w-full px-4 py-2 rounded-xl border text-center transition duration-200 focus:ring-2 focus:ring-indigo-600
                     ${
                       selectedGender === gender
-                        ? "bg-white text-blue-600 border-blue-600 font-semibold"
-                        : "bg-blue-600 text-white border-transparent"
+                        ? "bg-white text-indigo-600 border-indigo-600 font-semibold"
+                        : "bg-indigo-600 text-white border-transparent hover:bg-indigo-700"
                     }`}
                 >
                   {gender}

--- a/app/form/step3/page.js
+++ b/app/form/step3/page.js
@@ -81,17 +81,25 @@ export default function Step3() {
           <div className="space-y-4 text-center">
             <h2 className="text-lg">What was the number?</h2>
             <input
-              type="text"
-              className="border px-4 py-2 rounded w-full text-center"
+              type="number"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              min="0"
+              className="border px-4 py-2 rounded w-full text-center focus:ring-2 focus:ring-indigo-600"
               value={userInput}
-              onChange={(e) => setUserInput(e.target.value)}
+              onChange={(e) => setUserInput(e.target.value.replace(/\D/g, ""))}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  handleSubmit();
+                }
+              }}
               disabled={!!feedback}
             />
             {feedback && (
               <div className="mt-3 text-xl font-semibold">{feedback}</div>
             )}
             <button
-              className="bg-blue-600 text-white px-4 py-2 rounded"
+              className="bg-indigo-600 text-white px-4 py-2 rounded-xl transition duration-200 hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-600"
               onClick={handleSubmit}
               disabled={!!feedback}
             >
@@ -108,7 +116,7 @@ export default function Step3() {
               The real test begins now. Concentrate!
             </p>
             <button
-              className="bg-green-600 text-white px-4 py-2 rounded"
+              className="bg-green-600 text-white px-4 py-2 rounded-xl transition duration-200 hover:bg-green-700 focus:ring-2 focus:ring-green-600"
               onClick={() => router.push("/form/step4")}
             >
               Start Test
@@ -121,7 +129,7 @@ export default function Step3() {
   };
 
   return (
-    <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-lg min-h-[300px] flex items-center justify-center">
+    <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-2xl min-h-[300px] flex items-center justify-center">
       {renderContent()}
     </div>
   );

--- a/app/form/step4/page.js
+++ b/app/form/step4/page.js
@@ -56,7 +56,7 @@ export default function Step4() {
     });
   
     return (
-      <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-lg min-h-[300px] flex flex-col items-center justify-center space-y-4">
+      <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-2xl min-h-[300px] flex flex-col items-center justify-center space-y-4">
         <div className="text-xl font-bold">Test finished</div>
         <div>
           <pre className="text-left">
@@ -64,7 +64,7 @@ export default function Step4() {
           </pre>
         </div>
         <button
-          className="bg-gray-700 text-white px-4 py-2 rounded"
+          className="bg-gray-700 text-white px-4 py-2 rounded-xl transition duration-200 hover:bg-gray-800 focus:ring-2 focus:ring-gray-600"
           onClick={() => router.push("/")}
         >
           Back to Home

--- a/app/page.js
+++ b/app/page.js
@@ -14,7 +14,7 @@ export default function Home() {
       <div className="flex items-center justify-center">
         <Link
           href={"/form"}
-          className=" bg-indigo-600 text-white font-bold shadow-xl shadow-indigo-200  px-12 py-6 mx-auto rounded-xl"
+          className="bg-indigo-600 text-white font-bold shadow-xl shadow-indigo-200 px-12 py-6 mx-auto rounded-xl transition duration-200 hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-600"
         >
           Get Started
         </Link>

--- a/components/DigitTestSection.js
+++ b/components/DigitTestSection.js
@@ -118,15 +118,23 @@ export default function DigitTestSection({ length, count, onFinish }) {
       <div className="space-y-4 text-center">
         <h2 className="text-lg">What was the number?</h2>
         <input
-          type="text"
-          className="border px-4 py-2 rounded w-full text-center"
+          type="number"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          min="0"
+          className="border px-4 py-2 rounded w-full text-center focus:ring-2 focus:ring-indigo-600"
           value={userInput}
-          onChange={(e) => setUserInput(e.target.value)}
+          onChange={(e) => setUserInput(e.target.value.replace(/\D/g, ""))}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              handleSubmit();
+            }
+          }}
           disabled={!!feedback}
           autoFocus
         />
         <button
-          className="bg-blue-600 text-white px-4 py-2 rounded"
+          className="bg-indigo-600 text-white px-4 py-2 rounded-xl transition duration-200 hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-600"
           onClick={handleSubmit}
           disabled={!!feedback}
         >

--- a/components/InstructionWrapper.jsx
+++ b/components/InstructionWrapper.jsx
@@ -22,7 +22,7 @@ export default function InstructionWrapper({ steps, onFinish, children }) {
   };
 
   return (
-    <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-lg space-y-4">
+    <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-2xl space-y-4">
       <div className="text-lg font-semibold">{currentStep.label}</div>
 
       {/* Render current step content */}
@@ -32,7 +32,7 @@ export default function InstructionWrapper({ steps, onFinish, children }) {
       <div className="w-full flex items-center justify-between">
         {current > 0 ? (
           <button
-            className="p-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400"
+            className="p-2 bg-gray-300 text-gray-700 rounded-xl transition duration-200 hover:bg-gray-400 focus:ring-2 focus:ring-gray-400"
             onClick={handlePrevious}
           >
             Previous
@@ -41,7 +41,7 @@ export default function InstructionWrapper({ steps, onFinish, children }) {
           <div /> // Empty space to keep layout consistent
         )}
         <button
-          className="p-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          className="p-2 bg-indigo-600 text-white rounded-xl transition duration-200 hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-600"
           onClick={handleNext}
         >
           {current < steps.length - 1 ? "Next" : "Finish"}

--- a/components/QuestionWrapper.jsx
+++ b/components/QuestionWrapper.jsx
@@ -25,16 +25,16 @@ export default function QuestionWrapper({ steps, onFinish, children }) {
   };
 
   return (
-    <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-lg space-y-4">
+    <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-2xl space-y-4">
       <div className="text-lg font-semibold">{currentStep.label}</div>
 
-      {children({ step: currentStep, onNext: handleAnswer })}
+      {children({ step: currentStep, onNext: handleAnswer, onSubmit: handleNext })}
 
       <div className="w-full px-8 py-4 flex items-center justify-end">
         <button
-          className={`p-2 rounded-xl transition ${
+          className={`p-2 rounded-xl transition duration-200 focus:ring-2 focus:ring-indigo-600 ${
             currentAnswer
-              ? "bg-blue-600 text-white"
+              ? "bg-indigo-600 text-white hover:bg-indigo-700"
               : "bg-gray-300 text-gray-500 cursor-not-allowed"
           }`}
           disabled={!currentAnswer}


### PR DESCRIPTION
## Summary
- enforce positive age value and handle Enter key to submit
- allow digits only in training and test inputs
- add keyboard submission to digit tests
- refresh button and card styles with indigo theme
- add smooth transitions to navigation buttons and links

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b31ac92c832997e7be801ffc9f10