### PR TITLE
Refactor Step 4 to standard digit span

### DIFF
--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -14,14 +14,8 @@ export async function POST(req) {
     typeof id !== "string" ||
     !/^\d{5}$/.test(id) ||
     typeof score !== "object" ||
-    typeof +score.phase1 !== "number" ||
-    typeof +score.phase2 !== "number" ||
-    typeof +score.phase3 !== "number" ||
-    typeof +score.phase4 !== "number" ||
-    typeof +score.phase5 !== "number" ||
-    typeof +score.phase6 !== "number" ||
-    typeof +score.phase7 !== "number" ||
-    typeof +score.phase8 !== "number"
+    typeof +score.forward !== "number" ||
+    typeof +score.backward !== "number"
   ) {
     return NextResponse.json(
       { error: "Invalid input format" },

--- a/app/form/step4/page.js
+++ b/app/form/step4/page.js
@@ -1,106 +1,78 @@
 "use client";
-import { useState, useEffect, useRef } from "react";
+import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import DigitTestSection from "@/components/DigitTestSection";
-import heartIcon from "@/public/heart.svg";
-import Image from "next/image";
 import { useLanguage } from "@/components/LanguageProvider";
-const SECTIONS = [
-  { length: 2, count: 2, key: "phase1" },
-  { length: 3, count: 2, key: "phase2" },
-  { length: 4, count: 2, key: "phase3" },
-  { length: 5, count: 2, key: "phase4" },
-  { length: 6, count: 2, key: "phase5" },
-  { length: 7, count: 2, key: "phase6" },
-  { length: 8, count: 2, key: "phase7" },
-  { length: 9, count: 2, key: "phase8" },
-];
+
+const LENGTHS = [2, 3, 4, 5, 6, 7, 8, 9];
 
 export default function Step4() {
-  const [sectionIndex, setSectionIndex] = useState(0);
-  const [result, setResult] = useState({
-    phase1: 0,
-    phase2: 0,
-    phase3: 0,
-    phase4: 0,
-    phase5: 0,
-    phase6: 0,
-    phase7: 0,
-    phase8: 0,
-  });
-  const [isDone, setIsDone] = useState(false);
-  const [mistakeCount, setMistakeCount] = useState(0);
-  const [shouldShake, setShouldShake] = useState(false);
-  const router = useRouter();
   const { t } = useLanguage();
-  const prevMistake = useRef(mistakeCount);
-  useEffect(() => {
-    // فقط وقتی mistakeCount زیاد میشه (افزایشی)
-    if (mistakeCount > prevMistake.current) {
-      setShouldShake(true);
-      const timer = setTimeout(() => {
-        setShouldShake(false);
-      }, 3000);
-      // تمیزکاری تایمر
-      return () => clearTimeout(timer);
+  const router = useRouter();
+  const usedSequences = useRef(new Set());
+
+  const [task, setTask] = useState("forward"); // forward | break | backward | done
+  const [index, setIndex] = useState(0);
+  const [forwardScore, setForwardScore] = useState(0);
+  const [backwardScore, setBackwardScore] = useState(0);
+  const [isDone, setIsDone] = useState(false);
+  const [sectionKey, setSectionKey] = useState(0);
+
+  const handleFinish = (correctCount) => {
+    const length = LENGTHS[index];
+    if (correctCount > 0) {
+      if (task === "forward") setForwardScore(length);
+      else setBackwardScore(length);
+    } else {
+      if (task === "forward") {
+        setTask("break");
+        setIndex(0);
+        setSectionKey((k) => k + 1);
+        return;
+      }
+      setIsDone(true);
+      return;
     }
-    prevMistake.current = mistakeCount;
-  }, [mistakeCount]);
-  // این تابع رو به DigitTestSection می‌دیم
-  const handleSectionFinish = (score) => {
-    setResult((prev) => ({
-      ...prev,
-      [SECTIONS[sectionIndex].key]: score,
-    }));
-    if (sectionIndex + 1 < SECTIONS.length) {
-      setSectionIndex(sectionIndex + 1);
+
+    if (index + 1 < LENGTHS.length) {
+      setIndex(index + 1);
+      setSectionKey((k) => k + 1);
+    } else if (task === "forward") {
+      setTask("break");
+      setIndex(0);
+      setSectionKey((k) => k + 1);
     } else {
       setIsDone(true);
     }
   };
 
-  // وقتی تست تموم شد، ذخیره در localStorage (فقط یکبار)
   if (isDone) {
-    // اطلاعات کاربر و نتیجه رو بگیر
     const user = JSON.parse(localStorage.getItem("reflecta-user") || "{}");
     const resultToSave = {
       code: user.code,
       gender: user.gender,
       id: user.id,
-      score: { ...result },
+      score: { forward: forwardScore, backward: backwardScore },
     };
-
-    // نتیجه رو ذخیره کن
     localStorage.setItem("result", JSON.stringify(resultToSave));
-    // reflecta-user رو پاک کن
     localStorage.removeItem("reflecta-user");
-    console.log(resultToSave);
-    // داده رو بفرست به سرور
     fetch("/api/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(resultToSave),
     }).finally(() => {
-      // بعد از ارسال، کل localStorage رو پاک کن
       localStorage.clear();
     });
-
     return (
       <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-2xl min-h-[300px] flex flex-col items-center justify-center space-y-4">
         <div className="text-xl font-bold">{t("test_finished")}</div>
-        <div>
-          <pre className="text-left">
-            {t("your_score")}{" "}
-            {result?.phase1 +
-              result?.phase2 +
-              result?.phase3 +
-              result?.phase4 +
-              result?.phase5 +
-              result?.phase6 +
-              result?.phase7 +
-              result?.phase8}
-            /16
-          </pre>
+        <div className="text-center">
+          <p>
+            {t("forward_score")}: {forwardScore}
+          </p>
+          <p>
+            {t("backward_score")}: {backwardScore}
+          </p>
         </div>
         <button
           className="bg-gray-700 text-white px-4 py-2 rounded-xl transition duration-200 hover:bg-gray-800 focus:ring-2 focus:ring-gray-600"
@@ -112,33 +84,30 @@ export default function Step4() {
     );
   }
 
-  // فقط یه بخش فعاله
+  if (task === "break") {
+    return (
+      <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-2xl min-h-[300px] flex flex-col items-center justify-center space-y-4">
+        <p className="text-lg text-center">{t("rest_before_backward")}</p>
+        <button
+          className="bg-indigo-600 text-white px-4 py-2 rounded-xl transition duration-200 hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-600"
+          onClick={() => setTask("backward")}
+        >
+          {t("continue")}
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <>
-      <div className="w-full flex items-center justify-center gap-6">
-        {Array.from({ length: 3 - mistakeCount }).map((_, i) => (
-          <Image
-            key={i}
-            src={heartIcon}
-            width={24}
-            height={24}
-            alt="heart"
-            style={{ display: "inline", marginRight: "2px" }}
-            className={shouldShake ? " shake" : ""}
-          />
-        ))}
-      </div>
-      <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-lg min-h-[300px] flex items-center justify-center">
-        <DigitTestSection
-          mistakeCount={mistakeCount}
-          setMistakeCount={setMistakeCount}
-          setIsDone={setIsDone}
-          key={sectionIndex}
-          length={SECTIONS[sectionIndex].length}
-          count={SECTIONS[sectionIndex].count}
-          onFinish={handleSectionFinish}
-        />
-      </div>
-    </>
+    <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-lg min-h-[300px] flex items-center justify-center">
+      <DigitTestSection
+        key={sectionKey}
+        length={LENGTHS[index]}
+        count={2}
+        mode={task}
+        usedSequences={usedSequences.current}
+        onFinish={handleFinish}
+      />
+    </div>
   );
 }

--- a/components/DigitTestSection.js
+++ b/components/DigitTestSection.js
@@ -7,9 +7,8 @@ export default function DigitTestSection({
   length,
   count,
   onFinish,
-  mistakeCount,
-  setMistakeCount,
-  setIsDone,
+  mode = "forward",
+  usedSequences,
 }) {
   const [questionIndex, setQuestionIndex] = useState(0);
   const [numberArray, setNumberArray] = useState([]);
@@ -20,17 +19,17 @@ export default function DigitTestSection({
   const [score, setScore] = useState(0);
   const { t } = useLanguage();
 
-  // شروع سوال جدید: فاز رو ببر به intro
+  // شروع سوال جدید
   useEffect(() => {
     if (phase === "ready") {
-      const num = generateUniqueDigitNumber(length);
+      const num = generateUniqueDigitNumber(length, usedSequences);
       setNumberArray(num);
       setCurrentDigitIndex(0);
       setUserInput("");
       setFeedback("");
       setPhase("show");
     }
-  }, [phase, length, questionIndex]);
+  }, [phase, length, questionIndex, usedSequences]);
 
   // ترتیب نمایش پیام‌ها قبل از شروع سوال جدید
   useEffect(() => {
@@ -66,17 +65,16 @@ export default function DigitTestSection({
   useEffect(() => {
     if (phase === "input" && feedback) {
       const timer = setTimeout(() => {
-        if (feedback === "Correct") {
-          if (questionIndex + 1 < count) {
-            setScore((s) => s + 1);
-            setQuestionIndex((q) => q + 1);
-            setFeedback("");
-            setPhase("intro"); // شروع مجدد با پیام‌های قبل عدد
-          } else {
-            onFinish(score + 1);
-          }
+        const isCorrect = feedback === "Correct";
+        if (isCorrect) {
+          setScore((s) => s + 1);
+        }
+        if (questionIndex + 1 < count) {
+          setQuestionIndex((q) => q + 1);
+          setFeedback("");
+          setPhase("intro");
         } else {
-          onFinish(score);
+          onFinish(isCorrect ? score + 1 : score);
         }
       }, 1500);
       return () => clearTimeout(timer);
@@ -85,18 +83,16 @@ export default function DigitTestSection({
 
   // چک جواب کاربر
   const handleSubmit = () => {
-    if (userInput === numberArray.join("")) {
+    const correctSequence =
+      mode === "backward"
+        ? [...numberArray].reverse().join("")
+        : numberArray.join("");
+    if (userInput === correctSequence) {
       setFeedback("Correct");
       toast.success(t("correct"));
     } else {
       setFeedback("Wrong");
-      setMistakeCount(mistakeCount + 1);
-      console.log(mistakeCount);
-
       toast.error(t("wrong"));
-    }
-    if (mistakeCount >= 2) {
-      setIsDone(true);
     }
   };
 

--- a/models/User.js
+++ b/models/User.js
@@ -5,20 +5,8 @@ const UserSchema = new mongoose.Schema({
   gender: { type: String, required: true },
   username: { type: String, unique: true, required: true },
   score: {
-    phase1: { type: Number, default: 0 }, // 0 ~ 2
-    phase2: { type: Number, default: 0 }, // 0 ~ 2
-    phase3: { type: Number, default: 0 }  // 0 ~ 2
-    , // 0 ~ 2
-    phase4: { type: Number, default: 0 }
-    , // 0 ~ 2
-    phase5: { type: Number, default: 0 }
-    , // 0 ~ 2
-    phase6: { type: Number, default: 0 }
-    , // 0 ~ 2
-    phase7: { type: Number, default: 0 }
-    , // 0 ~ 2
-    phase8: { type: Number, default: 0 }
-    
+    forward: { type: Number, default: 0 },
+    backward: { type: Number, default: 0 },
   }
 }, { timestamps: true })
 

--- a/utils/randomNumberGenerator.js
+++ b/utils/randomNumberGenerator.js
@@ -1,26 +1,22 @@
-export default function generateUniqueDigitNumber(length) {
-    const digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
-    const result = []
-  
+export default function generateUniqueDigitNumber(length, usedSet = new Set()) {
+  const digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+  let result;
+  do {
+    result = [];
     while (result.length < length) {
-      const randIndex = Math.floor(Math.random() * digits.length)
-      const digit = digits[randIndex]
-  
-      // اگر رقم هنوز اضافه نشده
+      const randIndex = Math.floor(Math.random() * digits.length);
+      const digit = digits[randIndex];
       if (!result.includes(digit)) {
-        result.push(digit)
+        result.push(digit);
       }
     }
-  
-    // اگه عدد قراره چند رقمی باشه، نباید با صفر شروع شه
     if (result[0] === '0') {
-      const nonZeroIndex = result.findIndex((d) => d !== '0')
+      const nonZeroIndex = result.findIndex((d) => d !== '0');
       if (nonZeroIndex > 0) {
-        // جابه‌جایی صفر با عدد غیر صفر
-        [result[0], result[nonZeroIndex]] = [result[nonZeroIndex], result[0]]
+        [result[0], result[nonZeroIndex]] = [result[nonZeroIndex], result[0]];
       }
     }
-  
-    return result
-  }
-  
+  } while (usedSet.has(result.join('')));
+  usedSet.add(result.join(''));
+  return result;
+}

--- a/utils/translations.js
+++ b/utils/translations.js
@@ -36,6 +36,9 @@ export const translations = {
     previous: "Previous",
     next: "Next",
     finish: "Finish",
+    forward_score: "Forward score",
+    backward_score: "Backward score",
+    rest_before_backward: "Take a short rest, then continue with the backward task",
   },
   it: {
     beforeStartTitle: "Prima di iniziare...",
@@ -74,5 +77,8 @@ export const translations = {
     previous: "Precedente",
     next: "Avanti",
     finish: "Fine",
+    forward_score: "Punteggio forward",
+    backward_score: "Punteggio backward",
+    rest_before_backward: "Fai una breve pausa, poi continua con il test backward",
   },
 };


### PR DESCRIPTION
## Summary
- reimplement step 4 to run forward and backward digit span tasks
- track scores separately and save them to the backend
- make digit sequences unique across the whole test
- update API model and validation
- add translations for the new strings

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8692af348329ad6f595016fcbf21