### PR TITLE
Add backward digit span task with new scoring

### DIFF
--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -5,23 +5,23 @@ import generateUserId from "@/utils/generateUserId";
 
 export async function POST(req) {
   await connectToDB();
-  const { code, gender, id, score } = await req.json();
-  let userName = id;
+  const { code, gender, username, score } = await req.json();
+  let userName = username;
   // اعتبارسنجی اولیه
   if (
     typeof gender !== "string" ||
     !["Male", "Female", "Prefer Not to Say", "non-binary"].includes(gender) ||
-    typeof id !== "string" ||
-    !/^\d{5}$/.test(id) ||
+    typeof username !== "string" ||
+    !/^\d{5}$/.test(username) ||
     typeof score !== "object" ||
-    typeof +score.phase1 !== "number" ||
-    typeof +score.phase2 !== "number" ||
-    typeof +score.phase3 !== "number" ||
-    typeof +score.phase4 !== "number" ||
-    typeof +score.phase5 !== "number" ||
-    typeof +score.phase6 !== "number" ||
-    typeof +score.phase7 !== "number" ||
-    typeof +score.phase8 !== "number"
+    !Array.isArray(score.phase1) ||
+    !Array.isArray(score.phase2) ||
+    !Array.isArray(score.phase3) ||
+    !Array.isArray(score.phase4) ||
+    !Array.isArray(score.phase5) ||
+    !Array.isArray(score.phase6) ||
+    !Array.isArray(score.phase7) ||
+    !Array.isArray(score.phase8)
   ) {
     return NextResponse.json(
       { error: "Invalid input format" },
@@ -30,7 +30,7 @@ export async function POST(req) {
   }
 
   // چک آی‌دی تکراری
-  const existingUser = await User.findOne({ username: id });
+  const existingUser = await User.findOne({ username });
   if (existingUser) {
     userName = generateUserId();
   }

--- a/app/form/step4/page.js
+++ b/app/form/step4/page.js
@@ -5,6 +5,7 @@ import DigitTestSection from "@/components/DigitTestSection";
 import heartIcon from "@/public/heart.svg";
 import Image from "next/image";
 import { useLanguage } from "@/components/LanguageProvider";
+import generateUniqueDigitNumber from "@/utils/randomNumberGenerator";
 const SECTIONS = [
   { length: 2, count: 2, key: "phase1" },
   { length: 3, count: 2, key: "phase2" },
@@ -17,22 +18,25 @@ const SECTIONS = [
 ];
 
 export default function Step4() {
+  const [task, setTask] = useState("forward");
+  const [awaitingContinue, setAwaitingContinue] = useState(false);
   const [sectionIndex, setSectionIndex] = useState(0);
   const [result, setResult] = useState({
-    phase1: 0,
-    phase2: 0,
-    phase3: 0,
-    phase4: 0,
-    phase5: 0,
-    phase6: 0,
-    phase7: 0,
-    phase8: 0,
+    phase1: [0, 0],
+    phase2: [0, 0],
+    phase3: [0, 0],
+    phase4: [0, 0],
+    phase5: [0, 0],
+    phase6: [0, 0],
+    phase7: [0, 0],
+    phase8: [0, 0],
   });
   const [isDone, setIsDone] = useState(false);
   const [mistakeCount, setMistakeCount] = useState(0);
   const [shouldShake, setShouldShake] = useState(false);
   const router = useRouter();
   const { t } = useLanguage();
+  const usedSequences = useRef(new Set());
   const prevMistake = useRef(mistakeCount);
   useEffect(() => {
     // فقط وقتی mistakeCount زیاد میشه (افزایشی)
@@ -48,12 +52,32 @@ export default function Step4() {
   }, [mistakeCount]);
   // این تابع رو به DigitTestSection می‌دیم
   const handleSectionFinish = (score) => {
+    const key = SECTIONS[sectionIndex].key;
     setResult((prev) => ({
       ...prev,
-      [SECTIONS[sectionIndex].key]: score,
+      [key]: task === "forward" ? [score, prev[key][1]] : [prev[key][0], score],
     }));
+
+    if (score === 0) {
+      if (task === "forward") {
+        setTask("backward");
+        setSectionIndex(0);
+        setMistakeCount(0);
+        setAwaitingContinue(true);
+      } else {
+        setIsDone(true);
+      }
+      return;
+    }
+
     if (sectionIndex + 1 < SECTIONS.length) {
       setSectionIndex(sectionIndex + 1);
+      setMistakeCount(0);
+    } else if (task === "forward") {
+      setTask("backward");
+      setSectionIndex(0);
+      setMistakeCount(0);
+      setAwaitingContinue(true);
     } else {
       setIsDone(true);
     }
@@ -66,7 +90,7 @@ export default function Step4() {
     const resultToSave = {
       code: user.code,
       gender: user.gender,
-      id: user.id,
+      username: user.id,
       score: { ...result },
     };
 
@@ -90,16 +114,24 @@ export default function Step4() {
         <div className="text-xl font-bold">{t("test_finished")}</div>
         <div>
           <pre className="text-left">
-            {t("your_score")}{" "}
-            {result?.phase1 +
-              result?.phase2 +
-              result?.phase3 +
-              result?.phase4 +
-              result?.phase5 +
-              result?.phase6 +
-              result?.phase7 +
-              result?.phase8}
-            /16
+            {t("your_score")} {" "}
+            Forward: {result.phase1[0] +
+              result.phase2[0] +
+              result.phase3[0] +
+              result.phase4[0] +
+              result.phase5[0] +
+              result.phase6[0] +
+              result.phase7[0] +
+              result.phase8[0]}
+            /9 , Backward: {result.phase1[1] +
+              result.phase2[1] +
+              result.phase3[1] +
+              result.phase4[1] +
+              result.phase5[1] +
+              result.phase6[1] +
+              result.phase7[1] +
+              result.phase8[1]}
+            /9
           </pre>
         </div>
         <button
@@ -115,30 +147,52 @@ export default function Step4() {
   // فقط یه بخش فعاله
   return (
     <>
-      <div className="w-full flex items-center justify-center gap-6">
-        {Array.from({ length: 3 - mistakeCount }).map((_, i) => (
-          <Image
-            key={i}
-            src={heartIcon}
-            width={24}
-            height={24}
-            alt="heart"
-            style={{ display: "inline", marginRight: "2px" }}
-            className={shouldShake ? " shake" : ""}
-          />
-        ))}
-      </div>
-      <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-lg min-h-[300px] flex items-center justify-center">
-        <DigitTestSection
-          mistakeCount={mistakeCount}
-          setMistakeCount={setMistakeCount}
-          setIsDone={setIsDone}
-          key={sectionIndex}
-          length={SECTIONS[sectionIndex].length}
-          count={SECTIONS[sectionIndex].count}
-          onFinish={handleSectionFinish}
-        />
-      </div>
+      {!awaitingContinue && (
+        <>
+          <div className="w-full flex items-center justify-center gap-6">
+            {Array.from({ length: 3 - mistakeCount }).map((_, i) => (
+              <Image
+                key={i}
+                src={heartIcon}
+                width={24}
+                height={24}
+                alt="heart"
+                style={{ display: "inline", marginRight: "2px" }}
+                className={shouldShake ? " shake" : ""}
+              />
+            ))}
+          </div>
+          <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-lg min-h-[300px] flex items-center justify-center">
+            <DigitTestSection
+              mistakeCount={mistakeCount}
+              setMistakeCount={setMistakeCount}
+              key={`${task}-${sectionIndex}`}
+              length={SECTIONS[sectionIndex].length}
+              count={SECTIONS[sectionIndex].count}
+              onFinish={handleSectionFinish}
+              direction={task}
+              generateSequence={(len) => {
+                let seq;
+                do {
+                  seq = generateUniqueDigitNumber(len).join("");
+                } while (usedSequences.current.has(seq));
+                usedSequences.current.add(seq);
+                return seq.split("");
+              }}
+            />
+          </div>
+        </>
+      )}
+      {awaitingContinue && (
+        <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-2xl min-h-[300px] flex flex-col items-center justify-center space-y-4">
+          <button
+            className="bg-indigo-600 text-white px-4 py-2 rounded-xl transition duration-200 hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-600"
+            onClick={() => setAwaitingContinue(false)}
+          >
+            {t("continue")}
+          </button>
+        </div>
+      )}
     </>
   );
 }

--- a/components/DigitTestSection.js
+++ b/components/DigitTestSection.js
@@ -9,7 +9,8 @@ export default function DigitTestSection({
   onFinish,
   mistakeCount,
   setMistakeCount,
-  setIsDone,
+  direction = "forward",
+  generateSequence = generateUniqueDigitNumber,
 }) {
   const [questionIndex, setQuestionIndex] = useState(0);
   const [numberArray, setNumberArray] = useState([]);
@@ -23,14 +24,14 @@ export default function DigitTestSection({
   // شروع سوال جدید: فاز رو ببر به intro
   useEffect(() => {
     if (phase === "ready") {
-      const num = generateUniqueDigitNumber(length);
+      const num = generateSequence(length);
       setNumberArray(num);
       setCurrentDigitIndex(0);
       setUserInput("");
       setFeedback("");
       setPhase("show");
     }
-  }, [phase, length, questionIndex]);
+  }, [phase, length, questionIndex, generateSequence]);
 
   // ترتیب نمایش پیام‌ها قبل از شروع سوال جدید
   useEffect(() => {
@@ -66,17 +67,15 @@ export default function DigitTestSection({
   useEffect(() => {
     if (phase === "input" && feedback) {
       const timer = setTimeout(() => {
-        if (feedback === "Correct") {
-          if (questionIndex + 1 < count) {
-            setScore((s) => s + 1);
-            setQuestionIndex((q) => q + 1);
-            setFeedback("");
-            setPhase("intro"); // شروع مجدد با پیام‌های قبل عدد
-          } else {
-            onFinish(score + 1);
-          }
+        const increment = feedback === "Correct" ? 1 : 0;
+        const newScore = score + increment;
+        if (questionIndex + 1 < count) {
+          setScore(newScore);
+          setQuestionIndex((q) => q + 1);
+          setFeedback("");
+          setPhase("intro");
         } else {
-          onFinish(score);
+          onFinish(newScore);
         }
       }, 1500);
       return () => clearTimeout(timer);
@@ -85,18 +84,18 @@ export default function DigitTestSection({
 
   // چک جواب کاربر
   const handleSubmit = () => {
-    if (userInput === numberArray.join("")) {
+    const correct =
+      direction === "forward"
+        ? numberArray.join("")
+        : numberArray.slice().reverse().join("");
+
+    if (userInput === correct) {
       setFeedback("Correct");
       toast.success(t("correct"));
     } else {
       setFeedback("Wrong");
       setMistakeCount(mistakeCount + 1);
-      console.log(mistakeCount);
-
       toast.error(t("wrong"));
-    }
-    if (mistakeCount >= 2) {
-      setIsDone(true);
     }
   };
 

--- a/models/User.js
+++ b/models/User.js
@@ -1,25 +1,22 @@
 import mongoose from 'mongoose'
 
-const UserSchema = new mongoose.Schema({
-  code: { type: String, required: true },
-  gender: { type: String, required: true },
-  username: { type: String, unique: true, required: true },
-  score: {
-    phase1: { type: Number, default: 0 }, // 0 ~ 2
-    phase2: { type: Number, default: 0 }, // 0 ~ 2
-    phase3: { type: Number, default: 0 }  // 0 ~ 2
-    , // 0 ~ 2
-    phase4: { type: Number, default: 0 }
-    , // 0 ~ 2
-    phase5: { type: Number, default: 0 }
-    , // 0 ~ 2
-    phase6: { type: Number, default: 0 }
-    , // 0 ~ 2
-    phase7: { type: Number, default: 0 }
-    , // 0 ~ 2
-    phase8: { type: Number, default: 0 }
-    
-  }
-}, { timestamps: true })
+const UserSchema = new mongoose.Schema(
+  {
+    code: { type: String, required: true },
+    gender: { type: String, required: true },
+    username: { type: String, unique: true, required: true },
+    score: {
+      phase1: { type: [Number], default: [0, 0] }, // [forward, backward]
+      phase2: { type: [Number], default: [0, 0] },
+      phase3: { type: [Number], default: [0, 0] },
+      phase4: { type: [Number], default: [0, 0] },
+      phase5: { type: [Number], default: [0, 0] },
+      phase6: { type: [Number], default: [0, 0] },
+      phase7: { type: [Number], default: [0, 0] },
+      phase8: { type: [Number], default: [0, 0] },
+    },
+  },
+  { timestamps: true }
+)
 
 export default mongoose.models.User || mongoose.model('User', UserSchema)


### PR DESCRIPTION
## Summary
- extend digit-span task with forward and backward phases
- ensure unique digit sequences across the whole test
- show optional rest screen between tasks
- store per-phase scores as `[forward, backward]`
- update API validation and user schema for new score structure

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d9dea5ca0832985971def54ab8675