### PR TITLE
Update landing text and cleanup UI

### DIFF
--- a/app/form/step4/page.js
+++ b/app/form/step4/page.js
@@ -2,8 +2,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import DigitTestSection from "@/components/DigitTestSection";
-import heartIcon from "@/public/heart.svg";
-import Image from "next/image";
 import { useLanguage } from "@/components/LanguageProvider";
 import generateUniqueDigitNumber from "@/utils/randomNumberGenerator";
 const SECTIONS = [
@@ -34,22 +32,9 @@ export default function Step4() {
   });
   const [isDone, setIsDone] = useState(false);
   const [mistakeCount, setMistakeCount] = useState(0);
-  const [shouldShake, setShouldShake] = useState(false);
   const router = useRouter();
   const { t } = useLanguage();
   const usedSequences = useRef(new Set());
-  const prevMistake = useRef(mistakeCount);
-  useEffect(() => {
-    console.log(mistakeCount);
-    console.log(prevMistake);
-    setShouldShake(true);
-    const timer = setTimeout(() => {
-      setShouldShake(false);
-    }, 3000);
-
-    prevMistake.current = mistakeCount;
-    return () => clearTimeout(timer);
-  }, [mistakeCount]);
   // این تابع رو به DigitTestSection می‌دیم
   const handleSectionFinish = (score) => {
     const key = SECTIONS[sectionIndex].key;
@@ -154,19 +139,6 @@ export default function Step4() {
     <>
       {!awaitingContinue && (
         <>
-          <div className="w-full flex items-center justify-center gap-6">
-            {Array.from({ length: MAX_MISTAKES - mistakeCount }).map((_, i) => (
-              <Image
-                key={i}
-                src={heartIcon}
-                width={24}
-                height={24}
-                alt="heart"
-                style={{ display: "inline", marginRight: "2px" }}
-                className={shouldShake ? " shake" : ""}
-              />
-            ))}
-          </div>
           <div className="p-6 max-w-md mx-auto bg-white shadow-md rounded-lg min-h-[300px] flex items-center justify-center">
             <DigitTestSection
               mistakeCount={mistakeCount}

--- a/utils/translations.js
+++ b/utils/translations.js
@@ -1,8 +1,8 @@
 export const translations = {
   fa: {
-    beforeStartTitle: "قبل از شروع...",
+    beforeStartTitle: "به آزمون حافظه عددی خوش آمدید",
     beforeStartDescription:
-      "لطفاً پیش از آغاز آزمون، راهنمای زیر را مطالعه کنید.",
+      "در هر مرحله اعدادی نمایش داده می‌شوند؛ آن‌ها را به همان ترتیب و با دقت تکرار کنید.",
     getStarted: "شروع",
     step1_code_label: "نام کاربری شما در آزمون قبلی چه بود؟",
     step1_gender_label: "جنسیت شما چیست؟",
@@ -40,9 +40,9 @@ export const translations = {
     finish: "پایان",
   },
   it: {
-    beforeStartTitle: "Prima di iniziare...",
+    beforeStartTitle: "Benvenuto al test di memoria numerica",
     beforeStartDescription:
-      "Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ipsum odio provident, excepturi consectetur fugit optio delectus facere esse incidunt sed autem repellendus ipsam quod laboriosam possimus corrupti a voluptatem cumque.",
+      "Vedrai sequenze di cifre. Memorizzale e ripetile nell'ordine esatto in un ambiente tranquillo.",
     getStarted: "Inizia",
     step1_code_label: "Qual era il tuo nome utente nel test precedente?",
     step1_gender_label: "Qual è il tuo genere?",


### PR DESCRIPTION
## Summary
- remove heart icons from the digit test
- add concise instructions to translations for landing page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e93103188329bac832bcca2597e9